### PR TITLE
Add async TAP query notebook and query-all-history notebook

### DIFF
--- a/tap/history.ipynb
+++ b/tap/history.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf4b0ab6-2946-444b-a208-fe8821ea353a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lsst.rsp import get_query_history\n",
+    "hist=await get_query_history()\n",
+    "hist"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tap/history.ipynb
+++ b/tap/history.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "da335f6d",
+   "metadata": {},
+   "source": [
+    "### This notebook was rendered without parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cfee3f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set parameters for testing\n",
+    "# This code cell will be replaced by Times Square\n",
+    "# There are no parameters to set"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "bf4b0ab6-2946-444b-a208-fe8821ea353a",

--- a/tap/history.yaml
+++ b/tap/history.yaml
@@ -1,0 +1,10 @@
+title: TAP query history
+description: Retrieve (possibly long) list of query IDs for a user
+authors:
+  - name: Adam Thornton
+    slack: adam
+tags:
+  - tap
+  - query
+  - history
+parameters: {}

--- a/tap/query.ipynb
+++ b/tap/query.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "da335f6d",
+   "metadata": {},
+   "source": [
+    "### This notebook was rendered using `query_url` = {{params.query_url}}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cfee3f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set parameters for testing\n",
+    "# This code cell will be replaced by Times Square\n",
+    "query_url = 'https://rsp.example.com/api/tap/async/jobref_id'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cfee3f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lsst.rsp import retrieve_query\n",
+    "\n",
+    "# First, just get the AsyncTAPJob\n",
+    "query_data = retrieve_query(query_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c223d99f-657f-41c3-a90f-8f4b7c656987",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the result from the query data\n",
+    "query_result = query_data.fetch_result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc3babe4-66bf-4e92-97d0-0dc491d9f0b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert to a Pandas dataframe\n",
+    "query_df = query_result.to_table().to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cfee3f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display a preview of the pandas DataFrame\n",
+    "query_df"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "times-square": {
+   "values": {
+    "query_url": "https://data-dev.lsst.cloud/api/tap/async/r4qyb04xesh7mbz3"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tap/query.yaml
+++ b/tap/query.yaml
@@ -1,0 +1,13 @@
+title: Async TAP query
+description: Retrieve results from a an Async TAP query URL.
+authors:
+  - name: Adam Thornton
+    slack: adam
+tags:
+  - portal
+  - query
+parameters:
+  query_url:
+    type: string
+    description: URL referencing a specific async TAP user query.
+    default: https://rsp.example.com/api/tap/async/jobref_id


### PR DESCRIPTION
This is basically the same notebook as the Portal query, but it breaks up the chained resolution call so that we get a meaningful error if retrieval fails, or if fetching the result fails, or if the conversion to a dataframe fails.

Query-all-history has no parameters; it's just code the user could run to display a list of all the queries they've ever done.